### PR TITLE
Refactor Crowdfunding and LoyaltyPoints Contracts

### DIFF
--- a/src/work/SimpleDAO.sol
+++ b/src/work/SimpleDAO.sol
@@ -6,9 +6,13 @@ pragma solidity ^0.8.0;
  * @dev A more extensive version of a DAO that allows members to create proposals, vote on them, and execute proposals with various functionalities.
  */
 contract SimpleDAO {
+    enum ProposalType { Regular, Membership, Funding }
+    enum ProposalState { Pending, Active, Succeeded, Defeated, Executed }
+
     struct Proposal {
+        ProposalType proposalType;
+        ProposalState proposalState;
         string description;
-        bool executed;
         uint yesVotes;
         uint noVotes;
         mapping(address => bool) voted;
@@ -16,22 +20,34 @@ contract SimpleDAO {
         uint expiryTime;
         address target;
         bytes callData;
+        uint deposit;
+    }
+
+    struct Member {
+        bool isMember;
+        uint votingPower;
+        address delegate;
     }
 
     address public owner;
-    mapping(address => bool) public members;
-    mapping(address => uint) public votingPower;
-    uint public totalMembers; // Track total members for quorum calculation
+    mapping(address => Member) public members;
+    uint public totalMembers;
     Proposal[] public proposals;
 
-    uint public yesVoteThreshold = 50; // 50% approval required for a proposal to pass
-    uint public quorum = 25; // 25% of members must vote for a proposal to be valid
-    uint public constant MAX_DESCRIPTION_LENGTH = 200; // Maximum length for proposal descriptions
+    uint public yesVoteThreshold = 50;
+    uint public quorum = 25;
+    uint public proposalDeposit = 1 ether;
+    uint public timelockDuration = 24 hours;
+    bool public emergencyStop;
 
-    event ProposalCreated(uint indexed proposalId, string description, uint expiryTime, address target, bytes callData);
+    uint public constant MAX_DESCRIPTION_LENGTH = 200;
+
+    event ProposalCreated(uint indexed proposalId, ProposalType proposalType, string description, uint expiryTime, address target, bytes callData);
     event Voted(uint indexed proposalId, address voter, bool vote);
     event ProposalExecuted(uint indexed proposalId, bool success);
     event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
+    event EmergencyStopActivated();
+    event EmergencyStopDeactivated();
 
     modifier onlyOwner() {
         require(msg.sender == owner, "Only the owner can perform this action");
@@ -39,14 +55,18 @@ contract SimpleDAO {
     }
 
     modifier onlyMember() {
-        require(members[msg.sender], "Not a member");
+        require(members[msg.sender].isMember, "Not a member");
+        _;
+    }
+
+    modifier notEmergencyStop() {
+        require(!emergencyStop, "Emergency stop is activated");
         _;
     }
 
     constructor() {
         owner = msg.sender;
-        // Initially, only the contract owner is a member
-        _addMember(owner); // Use internal function to ensure totalMembers is updated
+        _addMember(owner);
     }
 
     /**
@@ -67,7 +87,7 @@ contract SimpleDAO {
     function addMember(address _member, uint _votingPower) external onlyOwner {
         require(_votingPower > 0, "Voting power must be greater than zero");
         _addMember(_member);
-        votingPower[_member] = _votingPower;
+        members[_member].votingPower = _votingPower;
     }
 
     /**
@@ -75,8 +95,8 @@ contract SimpleDAO {
      * @param _member The address of the new member.
      */
     function _addMember(address _member) internal {
-        if (!members[_member]) { // Check to prevent double counting
-            members[_member] = true;
+        if (!members[_member].isMember) {
+            members[_member].isMember = true;
             totalMembers++;
         }
     }
@@ -86,10 +106,10 @@ contract SimpleDAO {
      * @param _member The address of the member to remove.
      */
     function removeMember(address _member) external onlyOwner {
-        if (members[_member]) { // Ensure the address is currently a member
-            members[_member] = false;
+        if (members[_member].isMember) {
+            members[_member].isMember = false;
             totalMembers--;
-            delete votingPower[_member];
+            delete members[_member];
         }
     }
 
@@ -112,24 +132,51 @@ contract SimpleDAO {
     }
 
     /**
+     * @dev Allows a member to delegate their voting power to another member.
+     * @param _delegate The address of the member to delegate voting power to.
+     */
+    function delegateVotingPower(address _delegate) external onlyMember {
+        require(members[_delegate].isMember, "Delegate must be a member");
+        members[msg.sender].delegate = _delegate;
+    }
+
+    /**
+     * @dev Allows a member to revoke their voting power delegation.
+     */
+    function revokeDelegation() external onlyMember {
+        delete members[msg.sender].delegate;
+    }
+
+    /**
      * @dev Allows a member to create a new proposal.
+     * @param _proposalType The type of the proposal.
      * @param _description The description of the proposal.
      * @param _expiryTime The expiry time of the proposal.
      * @param _target The target address for the proposal execution.
      * @param _callData The call data for the proposal execution.
      */
-    function createProposal(string memory _description, uint _expiryTime, address _target, bytes memory _callData) external onlyMember {
+    function createProposal(
+        ProposalType _proposalType,
+        string memory _description,
+        uint _expiryTime,
+        address _target,
+        bytes memory _callData
+    ) external payable onlyMember notEmergencyStop {
         require(bytes(_description).length <= MAX_DESCRIPTION_LENGTH, "Description too long");
         require(_expiryTime > block.timestamp, "Expiry time must be in the future");
+        require(msg.value == proposalDeposit, "Incorrect proposal deposit");
 
         Proposal storage newProposal = proposals.push();
+        newProposal.proposalType = _proposalType;
+        newProposal.proposalState = ProposalState.Pending;
         newProposal.description = _description;
         newProposal.creationTime = block.timestamp;
         newProposal.expiryTime = _expiryTime;
         newProposal.target = _target;
         newProposal.callData = _callData;
+        newProposal.deposit = msg.value;
 
-        emit ProposalCreated(proposals.length - 1, _description, _expiryTime, _target, _callData);
+        emit ProposalCreated(proposals.length - 1, _proposalType, _description, _expiryTime, _target, _callData);
     }
 
     /**
@@ -137,42 +184,57 @@ contract SimpleDAO {
      * @param _proposalId The ID of the proposal to vote on.
      * @param _vote The vote (true for yes, false for no).
      */
-    function vote(uint _proposalId, bool _vote) external onlyMember {
+    function vote(uint _proposalId, bool _vote) external onlyMember notEmergencyStop {
         Proposal storage proposal = proposals[_proposalId];
+        require(proposal.proposalState == ProposalState.Active, "Proposal is not active");
         require(block.timestamp <= proposal.expiryTime, "Proposal has expired");
         require(!proposal.voted[msg.sender], "Already voted");
 
         proposal.voted[msg.sender] = true;
 
+        uint votingPower = _getVotingPower(msg.sender);
         if (_vote) {
-            proposal.yesVotes += votingPower[msg.sender];
+            proposal.yesVotes += votingPower;
         } else {
-            proposal.noVotes += votingPower[msg.sender];
+            proposal.noVotes += votingPower;
         }
 
         emit Voted(_proposalId, msg.sender, _vote);
+
+        _updateProposalState(_proposalId);
     }
 
     /**
      * @dev Executes a proposal if it meets the quorum and voting threshold.
      * @param _proposalId The ID of the proposal to execute.
      */
-    function executeProposal(uint _proposalId) external onlyMember {
+    function executeProposal(uint _proposalId) external onlyMember notEmergencyStop {
         Proposal storage proposal = proposals[_proposalId];
+        require(proposal.proposalState == ProposalState.Succeeded, "Proposal has not succeeded");
+        require(block.timestamp > proposal.expiryTime + timelockDuration, "Timelock duration has not passed");
         require(!proposal.executed, "Proposal already executed");
-        require(block.timestamp <= proposal.expiryTime, "Proposal has expired");
 
-        uint participatingMembers = proposal.yesVotes + proposal.noVotes;
-        require(participatingMembers * 100 / totalMembers >= quorum, "Quorum not reached");
-
-        bool success = proposal.yesVotes * 100 / participatingMembers >= yesVoteThreshold;
-        if (success) {
-            proposal.executed = true;
-            (bool execSuccess,) = proposal.target.call(proposal.callData);
-            require(execSuccess, "Proposal execution failed");
-        }
+        proposal.executed = true;
+        (bool success,) = proposal.target.call{value: proposal.deposit}(proposal.callData);
+        require(success, "Proposal execution failed");
 
         emit ProposalExecuted(_proposalId, success);
+    }
+
+    /**
+     * @dev Allows the contract owner to activate the emergency stop.
+     */
+    function activateEmergencyStop() external onlyOwner {
+        emergencyStop = true;
+        emit EmergencyStopActivated();
+    }
+
+    /**
+     * @dev Allows the contract owner to deactivate the emergency stop.
+     */
+    function deactivateEmergencyStop() external onlyOwner {
+        emergencyStop = false;
+        emit EmergencyStopDeactivated();
     }
 
     /**
@@ -181,5 +243,44 @@ contract SimpleDAO {
      */
     function getProposalCount() external view returns (uint) {
         return proposals.length;
+    }
+
+    /**
+     * @dev Internal function to update the state of a proposal.
+     * @param _proposalId The ID of the proposal to update.
+     */
+    function _updateProposalState(uint _proposalId) internal {
+        Proposal storage proposal = proposals[_proposalId];
+
+        if (proposal.proposalState == ProposalState.Pending && block.timestamp > proposal.creationTime) {
+            proposal.proposalState = ProposalState.Active;
+        }
+
+        if (proposal.proposalState == ProposalState.Active && block.timestamp > proposal.expiryTime) {
+            uint participatingMembers = proposal.yesVotes + proposal.noVotes;
+            if (participatingMembers * 100 / totalMembers >= quorum) {
+                if (proposal.yesVotes * 100 / participatingMembers >= yesVoteThreshold) {
+                    proposal.proposalState = ProposalState.Succeeded;
+                } else {
+                    proposal.proposalState = ProposalState.Defeated;
+                }
+            } else {
+                proposal.proposalState = ProposalState.Defeated;
+            }
+        }
+    }
+
+    /**
+     * @dev Internal function to get the voting power of a member.
+     * @param _member The address of the member.
+     * @return The voting power of the member.
+     */
+    function _getVotingPower(address _member) internal view returns (uint) {
+        address delegate = members[_member].delegate;
+        if (delegate != address(0)) {
+            return members[delegate].votingPower;
+        } else {
+            return members[_member].votingPower;
+        }
     }
 }

--- a/src/work/SimpleDAO_new.sol
+++ b/src/work/SimpleDAO_new.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title SimpleDAO
+ * @dev A more extensive version of a DAO that allows members to create proposals, vote on them, and execute proposals with various functionalities.
+ */
+contract SimpleDAO {
+    enum ProposalType { Regular, Membership, Funding }
+    enum ProposalState { Pending, Active, Succeeded, Defeated, Executed }
+
+    struct Proposal {
+        ProposalType proposalType;
+        ProposalState proposalState;
+        string description;
+        uint yesVotes;
+        uint noVotes;
+        mapping(address => bool) voted;
+        uint creationTime;
+        uint expiryTime;
+        address target;
+        bytes callData;
+        uint deposit;
+    }
+
+    struct Member {
+        bool isMember;
+        uint votingPower;
+        address delegate;
+    }
+
+    address public owner;
+    mapping(address => Member) public members;
+    uint public totalMembers;
+    Proposal[] public proposals;
+
+    uint public yesVoteThreshold = 50;
+    uint public quorum = 25;
+    uint public proposalDeposit = 1 ether;
+    uint public timelockDuration = 24 hours;
+    bool public emergencyStop;
+
+    uint public constant MAX_DESCRIPTION_LENGTH = 200;
+
+    event ProposalCreated(uint indexed proposalId, ProposalType proposalType, string description, uint expiryTime, address target, bytes callData);
+    event Voted(uint indexed proposalId, address voter, bool vote);
+    event ProposalExecuted(uint indexed proposalId, bool success);
+    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
+    event EmergencyStopActivated();
+    event EmergencyStopDeactivated();
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Only the owner can perform this action");
+        _;
+    }
+
+    modifier onlyMember() {
+        require(members[msg.sender].isMember, "Not a member");
+        _;
+    }
+
+    modifier notEmergencyStop() {
+        require(!emergencyStop, "Emergency stop is activated");
+        _;
+    }
+
+    constructor() {
+        owner = msg.sender;
+        _addMember(owner);
+    }
+
+    /**
+     * @dev Allows the contract owner to transfer ownership.
+     * @param _newOwner The address of the new owner.
+     */
+    function transferOwnership(address _newOwner) external onlyOwner {
+        require(_newOwner != address(0), "New owner cannot be zero address");
+        emit OwnershipTransferred(owner, _newOwner);
+        owner = _newOwner;
+    }
+
+    /**
+     * @dev Allows the contract owner to add a new member.
+     * @param _member The address of the new member.
+     * @param _votingPower The voting power of the new member.
+     */
+    function addMember(address _member, uint _votingPower) external onlyOwner {
+        require(_votingPower > 0, "Voting power must be greater than zero");
+        _addMember(_member);
+        members[_member].votingPower = _votingPower;
+    }
+
+    /**
+     * @dev Internal function to add a new member.
+     * @param _member The address of the new member.
+     */
+    function _addMember(address _member) internal {
+        if (!members[_member].isMember) {
+            members[_member].isMember = true;
+            totalMembers++;
+        }
+    }
+
+    /**
+     * @dev Allows the contract owner to remove a member.
+     * @param _member The address of the member to remove.
+     */
+    function removeMember(address _member) external onlyOwner {
+        if (members[_member].isMember) {
+            members[_member].isMember = false;
+            totalMembers--;
+            delete members[_member];
+        }
+    }
+
+    /**
+     * @dev Allows the contract owner to update the quorum.
+     * @param _quorum The new quorum percentage.
+     */
+    function updateQuorum(uint _quorum) external onlyOwner {
+        require(_quorum > 0 && _quorum <= 100, "Quorum must be between 1 and 100");
+        quorum = _quorum;
+    }
+
+    /**
+     * @dev Allows the contract owner to update the yes vote threshold.
+     * @param _yesVoteThreshold The new yes vote threshold percentage.
+     */
+    function updateYesVoteThreshold(uint _yesVoteThreshold) external onlyOwner {
+        require(_yesVoteThreshold > 0 && _yesVoteThreshold <= 100, "Yes vote threshold must be between 1 and 100");
+        yesVoteThreshold = _yesVoteThreshold;
+    }
+
+    /**
+     * @dev Allows a member to delegate their voting power to another member.
+     * @param _delegate The address of the member to delegate voting power to.
+     */
+    function delegateVotingPower(address _delegate) external onlyMember {
+        require(members[_delegate].isMember, "Delegate must be a member");
+        members[msg.sender].delegate = _delegate;
+    }
+
+    /**
+     * @dev Allows a member to revoke their voting power delegation.
+     */
+    function revokeDelegation() external onlyMember {
+        delete members[msg.sender].delegate;
+    }
+
+    /**
+     * @dev Allows a member to create a new proposal.
+     * @param _proposalType The type of the proposal.
+     * @param _description The description of the proposal.
+     * @param _expiryTime The expiry time of the proposal.
+     * @param _target The target address for the proposal execution.
+     * @param _callData The call data for the proposal execution.
+     */
+    function createProposal(
+        ProposalType _proposalType,
+        string memory _description,
+        uint _expiryTime,
+        address _target,
+        bytes memory _callData
+    ) external payable onlyMember notEmergencyStop {
+        require(bytes(_description).length <= MAX_DESCRIPTION_LENGTH, "Description too long");
+        require(_expiryTime > block.timestamp, "Expiry time must be in the future");
+        require(msg.value == proposalDeposit, "Incorrect proposal deposit");
+
+        Proposal storage newProposal = proposals.push();
+        newProposal.proposalType = _proposalType;
+        newProposal.proposalState = ProposalState.Pending;
+        newProposal.description = _description;
+        newProposal.creationTime = block.timestamp;
+        newProposal.expiryTime = _expiryTime;
+        newProposal.target = _target;
+        newProposal.callData = _callData;
+        newProposal.deposit = msg.value;
+
+        emit ProposalCreated(proposals.length - 1, _proposalType, _description, _expiryTime, _target, _callData);
+    }
+
+    /**
+     * @dev Allows a member to vote on a proposal.
+     * @param _proposalId The ID of the proposal to vote on.
+     * @param _vote The vote (true for yes, false for no).
+     */
+    function vote(uint _proposalId, bool _vote) external onlyMember notEmergencyStop {
+        Proposal storage proposal = proposals[_proposalId];
+        require(proposal.proposalState == ProposalState.Active, "Proposal is not active");
+        require(block.timestamp <= proposal.expiryTime, "Proposal has expired");
+        require(!proposal.voted[msg.sender], "Already voted");
+
+        proposal.voted[msg.sender] = true;
+
+        uint votingPower = _getVotingPower(msg.sender);
+        if (_vote) {
+            proposal.yesVotes += votingPower;
+        } else {
+            proposal.noVotes += votingPower;
+        }
+
+        emit Voted(_proposalId, msg.sender, _vote);
+
+        _updateProposalState(_proposalId);
+    }
+
+    /**
+     * @dev Executes a proposal if it meets the quorum and voting threshold.
+     * @param _proposalId The ID of the proposal to execute.
+     */
+    function executeProposal(uint _proposalId) external onlyMember notEmergencyStop {
+        Proposal storage proposal = proposals[_proposalId];
+        require(proposal.proposalState == ProposalState.Succeeded, "Proposal has not succeeded");
+        require(block.timestamp > proposal.expiryTime + timelockDuration, "Timelock duration has not passed");
+        require(!proposal.executed, "Proposal already executed");
+
+        proposal.executed = true;
+        (bool success,) = proposal.target.call{value: proposal.deposit}(proposal.callData);
+        require(success, "Proposal execution failed");
+
+        emit ProposalExecuted(_proposalId, success);
+    }
+
+    /**
+     * @dev Allows the contract owner to activate the emergency stop.
+     */
+    function activateEmergencyStop() external onlyOwner {
+        emergencyStop = true;
+        emit EmergencyStopActivated();
+    }
+
+    /**
+     * @dev Allows the contract owner to deactivate the emergency stop.
+     */
+    function deactivateEmergencyStop() external onlyOwner {
+        emergencyStop = false;
+        emit EmergencyStopDeactivated();
+    }
+
+    /**
+     * @dev Returns the total number of proposals.
+     * @return The number of proposals.
+     */
+    function getProposalCount() external view returns (uint) {
+        return proposals.length;
+    }
+
+    /**
+     * @dev Internal function to update the state of a proposal.
+     * @param _proposalId The ID of the proposal to update.
+     */
+    function _updateProposalState(uint _proposalId) internal {
+        Proposal storage proposal = proposals[_proposalId];
+
+        if (proposal.proposalState == ProposalState.Pending && block.timestamp > proposal.creationTime) {
+            proposal.proposalState = ProposalState.Active;
+        }
+
+        if (proposal.proposalState == ProposalState.Active && block.timestamp > proposal.expiryTime) {
+            uint participatingMembers = proposal.yesVotes + proposal.noVotes;
+            if (participatingMembers * 100 / totalMembers >= quorum) {
+                if (proposal.yesVotes * 100 / participatingMembers >= yesVoteThreshold) {
+                    proposal.proposalState = ProposalState.Succeeded;
+                } else {
+                    proposal.proposalState = ProposalState.Defeated;
+                }
+            } else {
+                proposal.proposalState = ProposalState.Defeated;
+            }
+        }
+    }
+
+    /**
+     * @dev Internal function to get the voting power of a member.
+     * @param _member The address of the member.
+     * @return The voting power of the member.
+     */
+    function _getVotingPower(address _member) internal view returns (uint) {
+        address delegate = members[_member].delegate;
+        if (delegate != address(0)) {
+            return members[delegate].votingPower;
+        } else {
+            return members[_member].votingPower;
+        }
+    }
+}

--- a/src/work/SimpleDEX.sol
+++ b/src/work/SimpleDEX.sol
@@ -1,223 +1,253 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./IERC20.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+// Import the IERC20 interface and SafeERC20 library from OpenZeppelin
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+// Import the ReentrancyGuard contract from OpenZeppelin for reentrancy protection
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+// Import the Ownable contract from OpenZeppelin for access control
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-/**
- * @title Simple Decentralized Exchange (DEX)
- * @dev A simplified version of a DEX allowing users to swap between two tokens (TokenA and TokenB).
- */
-contract SimpleDEX {
-    using SafeMath for uint256;
+// SimpleDEX contract inherits from ReentrancyGuard and Ownable contracts
+contract SimpleDEX is ReentrancyGuard, Ownable {
+    // Use SafeERC20 for safe token transfers and approvals
+    using SafeERC20 for IERC20;
 
-    address public owner;
-    IERC20 public tokenA;
-    IERC20 public tokenB;
-    uint256 public rateTokenAtoTokenB = 100; // Example rate: 1 TokenA = 100 TokenB
-    uint256 public feePercentage; // Fee percentage, e.g., 1 means 1%
+    // Immutable variables for token addresses to save gas on storage reads
+    IERC20 public immutable tokenA;
+    IERC20 public immutable tokenB;
+
+    // Exchange rate from tokenA to tokenB
+    uint256 public rateTokenAtoTokenB;
+    // Fee percentage for token swaps (in basis points, where 10000 = 100%)
+    uint256 public feePercentage;
+    // Flag to indicate if the contract is paused
     bool public isPaused;
+    // Flag to indicate if the emergency stop is activated
+    bool public emergencyStop;
+    // Slippage tolerance for token swaps (in basis points, where 10000 = 100%)
+    uint256 public slippageTolerance;
+    // Minimum swap amount allowed
+    uint256 public minSwapAmount;
+    // Maximum swap amount allowed
+    uint256 public maxSwapAmount;
 
-    bool private locked;
+    // Mapping to store whitelisted tokens
+    mapping(address => bool) public whitelistedTokens;
 
+    // Event emitted when a token swap occurs
     event TokenSwap(address indexed user, uint256 amountA, uint256 amountB, bool fromAToB);
+    // Event emitted when a fee is collected
     event FeeCollected(address indexed user, uint256 amount);
-    event TokenADeposited(address indexed user, uint256 amount);
-    event TokenBDeposited(address indexed user, uint256 amount);
-    event TokenAWithdrawn(address indexed user, uint256 amount);
-    event TokenBWithdrawn(address indexed user, uint256 amount);
+    // Event emitted when the exchange rate is updated
     event RateUpdated(uint256 newRate);
+    // Event emitted when the emergency stop is activated
+    event EmergencyStopActivated();
+    // Event emitted when the emergency stop is deactivated
+    event EmergencyStopDeactivated();
+    // Event emitted when a token is whitelisted
+    event TokenWhitelisted(address indexed token);
+    // Event emitted when a token is removed from the whitelist
+    event TokenRemovedFromWhitelist(address indexed token);
 
-    modifier onlyOwner() {
-        require(msg.sender == owner, "Only the owner can perform this action.");
-        _;
-    }
+    // Constructor function to initialize the contract
+    constructor(address _tokenA, address _tokenB, uint256 _rateTokenAtoTokenB, uint256 _feePercentage) {
+        // Ensure valid token addresses are provided
+        require(_tokenA != address(0) && _tokenB != address(0), "Invalid token addresses");
+        // Ensure the exchange rate is greater than zero
+        require(_rateTokenAtoTokenB > 0, "Rate must be greater than zero");
+        // Ensure the fee percentage is between 0 and 100 (inclusive)
+        require(_feePercentage <= 10000, "Fee percentage must be between 0 and 100");
 
-    modifier noReentrant() {
-        require(!locked, "Reentrant call detected.");
-        locked = true;
-        _;
-        locked = false;
-    }
-
-    modifier whenNotPaused() {
-        require(!isPaused, "Contract is paused.");
-        _;
-    }
-
-    constructor(address _tokenA, address _tokenB, uint256 _feePercentage) {
-        owner = msg.sender;
+        // Set the token addresses
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
+        // Set the initial exchange rate
+        rateTokenAtoTokenB = _rateTokenAtoTokenB;
+        // Set the initial fee percentage
         feePercentage = _feePercentage;
+        // Set the default slippage tolerance to 0.5%
+        slippageTolerance = 50;
+        // Set the default minimum swap amount to 1 token
+        minSwapAmount = 1e18;
+        // Set the default maximum swap amount to 1,000,000 tokens
+        maxSwapAmount = 1e24;
+        // Whitelist the initial tokens
+        whitelistedTokens[_tokenA] = true;
+        whitelistedTokens[_tokenB] = true;
     }
 
-    /**
-     * @dev Allows the owner to set the exchange rate from TokenA to TokenB.
-     * @param _rate New rate for swapping TokenA to TokenB.
-     */
+    // Function to set the exchange rate (only callable by the contract owner)
     function setRate(uint256 _rate) external onlyOwner {
-        require(_rate > 0, "Rate must be greater than zero.");
+        // Ensure the new rate is greater than zero
+        require(_rate > 0, "Rate must be greater than zero");
+        // Update the exchange rate
         rateTokenAtoTokenB = _rate;
+        // Emit an event indicating the rate update
         emit RateUpdated(_rate);
     }
 
-    /**
-     * @dev Swaps an amount of TokenA held by the caller to TokenB according to the current rate.
-     * The caller must have approved this contract to spend the relevant amount of TokenA.
-     * @param _amount The amount of TokenA to swap for TokenB.
-     */
-    function swapTokenAForTokenB(uint256 _amount) external noReentrant whenNotPaused {
-        require(_amount > 0, "Amount must be greater than zero.");
+    // Function to swap tokenA for tokenB
+    function swapTokenAForTokenB(uint256 _amount) external nonReentrant whenNotPaused whenNotEmergencyStopped {
+        // Ensure the swap amount is within the allowed range
+        require(_amount >= minSwapAmount && _amount <= maxSwapAmount, "Swap amount out of range");
+        // Ensure both tokens are whitelisted
+        require(whitelistedTokens[address(tokenA)] && whitelistedTokens[address(tokenB)], "Tokens are not whitelisted");
 
-        uint256 tokenBAmountBeforeFee = _amount.mul(rateTokenAtoTokenB).div(10**18); // Adjust precision as needed
-        uint256 feeAmount = tokenBAmountBeforeFee.mul(feePercentage).div(100);
-        uint256 tokenBAmount = tokenBAmountBeforeFee.sub(feeAmount);
+        // Calculate the amount of tokenB to receive based on the exchange rate
+        uint256 tokenBAmount = (_amount * rateTokenAtoTokenB) / 1e18;
+        // Calculate the fee amount
+        uint256 feeAmount = (tokenBAmount * feePercentage) / 10000;
+        // Calculate the amount of tokenB after deducting the fee
+        uint256 tokenBAmountAfterFee = tokenBAmount - feeAmount;
 
-        require(tokenB.balanceOf(address(this)) >= tokenBAmount, "Not enough TokenB in DEX for the swap.");
+        // Calculate the minimum amount of tokenB expected based on the slippage tolerance
+        uint256 minTokenBAmount = (tokenBAmountAfterFee * (10000 - slippageTolerance)) / 10000;
 
-        bool sentA = tokenA.transferFrom(msg.sender, address(this), _amount);
-        require(sentA, "Failed to transfer TokenA from user to DEX.");
+        // Transfer tokenA from the user to the contract
+        tokenA.safeTransferFrom(msg.sender, address(this), _amount);
+        // Transfer tokenB from the contract to the user
+        tokenB.safeTransfer(msg.sender, tokenBAmountAfterFee);
 
-        bool sentB = tokenB.transfer(msg.sender, tokenBAmount);
-        require(sentB, "Failed to transfer TokenB from DEX to user.");
-
-        emit TokenSwap(msg.sender, _amount, tokenBAmount, true);
+        // Emit events for the token swap and fee collection
+        emit TokenSwap(msg.sender, _amount, tokenBAmountAfterFee, true);
         emit FeeCollected(msg.sender, feeAmount);
 
-        // Transfer fee to owner
+        // If a fee was collected, transfer it to the contract owner
         if (feeAmount > 0) {
-            bool sentFee = tokenB.transfer(owner, feeAmount);
-            require(sentFee, "Failed to transfer fee to owner.");
+            tokenB.safeTransfer(owner(), feeAmount);
         }
+
+        // Ensure the received amount of tokenB is within the slippage tolerance
+        require(tokenB.balanceOf(msg.sender) >= minTokenBAmount, "Slippage tolerance exceeded");
     }
 
-    /**
-     * @dev Swaps an amount of TokenB held by the caller to TokenA according to the current rate.
-     * The caller must have approved this contract to spend the relevant amount of TokenB.
-     * @param _amount The amount of TokenB to swap for TokenA.
-     */
-    function swapTokenBForTokenA(uint256 _amount) external noReentrant whenNotPaused {
-        require(_amount > 0, "Amount must be greater than zero.");
+    // Function to swap tokenB for tokenA
+    function swapTokenBForTokenA(uint256 _amount) external nonReentrant whenNotPaused whenNotEmergencyStopped {
+        // Ensure the swap amount is within the allowed range
+        require(_amount >= minSwapAmount && _amount <= maxSwapAmount, "Swap amount out of range");
+        // Ensure both tokens are whitelisted
+        require(whitelistedTokens[address(tokenA)] && whitelistedTokens[address(tokenB)], "Tokens are not whitelisted");
 
-        uint256 tokenAAmount = _amount.mul(10**18).div(rateTokenAtoTokenB); // Adjust precision as needed
-        require(tokenA.balanceOf(address(this)) >= tokenAAmount, "Not enough TokenA in DEX for the swap.");
+        // Calculate the amount of tokenA to receive based on the exchange rate
+        uint256 tokenAAmount = (_amount * 1e18) / rateTokenAtoTokenB;
+        // Calculate the minimum amount of tokenA expected based on the slippage tolerance
+        uint256 minTokenAAmount = (tokenAAmount * (10000 - slippageTolerance)) / 10000;
 
-        bool sentB = tokenB.transferFrom(msg.sender, address(this), _amount);
-        require(sentB, "Failed to transfer TokenB from user to DEX.");
+        // Transfer tokenB from the user to the contract
+        tokenB.safeTransferFrom(msg.sender, address(this), _amount);
+        // Transfer tokenA from the contract to the user
+        tokenA.safeTransfer(msg.sender, tokenAAmount);
 
-        bool sentA = tokenA.transfer(msg.sender, tokenAAmount);
-        require(sentA, "Failed to transfer TokenA from DEX to user.");
-
+        // Emit an event for the token swap
         emit TokenSwap(msg.sender, _amount, tokenAAmount, false);
+
+        // Ensure the received amount of tokenA is within the slippage tolerance
+        require(tokenA.balanceOf(msg.sender) >= minTokenAAmount, "Slippage tolerance exceeded");
     }
 
-    /**
-     * @dev Allows the owner to withdraw any ERC20 tokens accidentally sent to this contract.
-     * @param _token Address of the ERC20 token to withdraw.
-     * @param _amount Amount of tokens to withdraw.
-     */
-    function withdrawToken(address _token, uint256 _amount) external onlyOwner {
-        require(_amount > 0, "Amount must be greater than zero.");
-        IERC20 token = IERC20(_token);
-        bool sent = token.transfer(owner, _amount);
-        require(sent, "Failed to withdraw tokens.");
-    }
-
-    /**
-     * @dev Allows the owner to withdraw any Ether accidentally sent to this contract.
-     * This function is for safety in case Ether is sent directly to the contract address.
-     */
-    function withdrawEther(uint256 _amount) external onlyOwner {
-        require(_amount > 0, "Amount must be greater than zero.");
-        payable(owner).transfer(_amount);
-    }
-
-    /**
-     * @dev Allows the owner to update the fee percentage.
-     * @param _feePercentage New fee percentage, e.g., 1 means 1%.
-     */
+    // Function to set the fee percentage (only callable by the contract owner)
     function setFeePercentage(uint256 _feePercentage) external onlyOwner {
-        require(_feePercentage >= 0  && _feePercentage <= 100, "Fee percentage must be between 0 and 100.");
+        // Ensure the fee percentage is between 0 and 100 (inclusive)
+        require(_feePercentage <= 10000, "Fee percentage must be between 0 and 100");
+        // Update the fee percentage
         feePercentage = _feePercentage;
     }
 
-    /**
-     * @dev Allows users to deposit TokenA into the contract.
-     * @param _amount The amount of TokenA to deposit.
-     */
-    function depositTokenA(uint256 _amount) external {
-        require(_amount > 0, "Amount must be greater than zero.");
-        bool sent = tokenA.transferFrom(msg.sender, address(this), _amount);
-        require(sent, "Failed to deposit TokenA.");
-        emit TokenADeposited(msg.sender, _amount);
+    // Function to set the slippage tolerance (only callable by the contract owner)
+    function setSlippageTolerance(uint256 _slippageTolerance) external onlyOwner {
+        // Ensure the slippage tolerance is between 0 and 100 (inclusive)
+        require(_slippageTolerance <= 10000, "Slippage tolerance must be between 0 and 100");
+        // Update the slippage tolerance
+        slippageTolerance = _slippageTolerance;
     }
 
-    /**
-     * @dev Allows the owner to withdraw TokenA from the contract.
-     * @param _amount The amount of TokenA to withdraw.
-     */
-    function withdrawTokenA(uint256 _amount) external onlyOwner {
-        require(_amount > 0, "Amount must be greater than zero.");
-        bool sent = tokenA.transfer(owner, _amount);
-        require(sent, "Failed to withdraw TokenA.");
-        emit TokenAWithdrawn(msg.sender, _amount);
+    // Function to set the minimum swap amount (only callable by the contract owner)
+    function setMinSwapAmount(uint256 _minSwapAmount) external onlyOwner {
+        // Update the minimum swap amount
+        minSwapAmount = _minSwapAmount;
     }
 
-    /**
-     * @dev Allows users to deposit TokenB into the contract.
-     * @param _amount The amount of TokenB to deposit.
-     */
-    function depositTokenB(uint256 _amount) external {
-        require(_amount > 0, "Amount must be greater than zero.");
-        bool sent = tokenB.transferFrom(msg.sender, address(this), _amount);
-        require(sent, "Failed to deposit TokenB.");
-        emit TokenBDeposited(msg.sender, _amount);
+    // Function to set the maximum swap amount (only callable by the contract owner)
+    function setMaxSwapAmount(uint256 _maxSwapAmount) external onlyOwner {
+        // Update the maximum swap amount
+        maxSwapAmount = _maxSwapAmount;
     }
 
-    /**
-     * @dev Allows the owner to withdraw TokenB from the contract.
-     * @param _amount The amount of TokenB to withdraw.
-     */
-    function withdrawTokenB(uint256 _amount) external onlyOwner {
-        require(_amount > 0, "Amount must be greater than zero.");
-        bool sent = tokenB.transfer(owner, _amount);
-        require(sent, "Failed to withdraw TokenB.");
-        emit TokenBWithdrawn(msg.sender, _amount);
-    }
-
-    /**
-     * @dev Allows the owner to pause contract operations.
-     * This function can be used in case of emergencies or maintenance.
-     */
+    // Function to pause the contract (only callable by the contract owner)
     function pause() external onlyOwner {
+        // Set the pause flag to true
         isPaused = true;
     }
 
-    /**
-     * @dev Allows the owner to resume contract operations.
-     */
+    // Function to resume the contract (only callable by the contract owner)
     function resume() external onlyOwner {
+        // Set the pause flag to false
         isPaused = false;
     }
 
-    /**
-     * @dev Allows the owner to withdraw any Ether accidentally sent to this contract.
-     * This function is for safety in case Ether is sent directly to the contract address.
-     * @param _amount The amount of Ether to withdraw.
-     */
-    function withdrawEther(uint256 _amount) external onlyOwner {
-        require(_amount > 0, "Amount must be greater than zero.");
-        payable(owner).transfer(_amount);
+    // Function to toggle the emergency stop (only callable by the contract owner)
+    function toggleEmergencyStop() external onlyOwner {
+        // Toggle the emergency stop flag
+        emergencyStop = !emergencyStop;
+        // Emit the appropriate event based on the emergency stop state
+        if (emergencyStop) {
+            emit EmergencyStopActivated();
+        } else {
+            emit EmergencyStopDeactivated();
+        }
     }
 
-    /**
-     * @dev Allows the owner to update the fee percentage.
-     * @param _feePercentage New fee percentage, e.g., 1 means 1%.
-     */
-    function setFeePercentage(uint256 _feePercentage) external onlyOwner {
-        require(_feePercentage >= 0 && _feePercentage <= 100, "Fee percentage must be between 0 and 100.");
-        feePercentage = _feePercentage;
+    // Function to add a token to the whitelist (only callable by the contract owner)
+    function addWhitelistedToken(address _token) external onlyOwner {
+        // Ensure a valid token address is provided
+        require(_token != address(0), "Invalid token address");
+        // Add the token to the whitelist
+        whitelistedTokens[_token] = true;
+        // Emit an event indicating the token whitelisting
+        emit TokenWhitelisted(_token);
+    }
+
+    // Function to remove a token from the whitelist (only callable by the contract owner)
+    function removeWhitelistedToken(address _token) external onlyOwner {
+        // Ensure a valid token address is provided
+        require(_token != address(0), "Invalid token address");
+        // Remove the token from the whitelist
+        whitelistedTokens[_token] = false;
+        // Emit an event indicating the token removal from the whitelist
+        emit TokenRemovedFromWhitelist(_token);
+    }
+
+    // Function to withdraw tokens from the contract (only callable by the contract owner)
+    function withdrawTokens(address _token, uint256 _amount) external onlyOwner {
+        // Ensure the withdrawal amount is greater than zero
+        require(_amount > 0, "Amount must be greater than zero");
+        // Transfer the specified amount of tokens to the contract owner
+        IERC20(_token).safeTransfer(owner(), _amount);
+    }
+
+    // Function to withdraw Ether from the contract (only callable by the contract owner)
+    function withdrawEther(uint256 _amount) external onlyOwner {
+        // Ensure the withdrawal amount is greater than zero
+        require(_amount > 0, "Amount must be greater than zero");
+        // Transfer the specified amount of Ether to the contract owner
+        payable(owner()).transfer(_amount);
+    }
+
+    // Modifier to check if the contract is not paused
+    modifier whenNotPaused() {
+        // Require that the contract is not paused
+        require(!isPaused, "Contract is paused");
+        // Continue with the function execution
+        _;
+    }
+
+    // Modifier to check if the emergency stop is not activated
+    modifier whenNotEmergencyStopped() {
+        // Require that the emergency stop is not activated
+        require(!emergencyStop, "Emergency stop is activated");
+        // Continue with the function execution
+        _;
     }
 }
-

--- a/src/work/SimpleDEXMe.sol
+++ b/src/work/SimpleDEXMe.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract SimpleDEX is ReentrancyGuard, Ownable {
+    using SafeERC20 for IERC20;
+    
+    IERC20 public immutable tokenA;
+    IERC20 public immutable tokenB;
+    uint256 public rateTokenAtoTokenB;
+    uint256 public feePercentage;
+    bool public isPaused;
+
+    event TokenSwap(address indexed user, uint256 amountA, uint256 amountB, bool fromAToB);
+    event FeeCollected(address indexed user, uint256 amount);
+    event RateUpdated(uint256 newRate);
+
+    constructor(address _tokenA, address _tokenB, uint256 _rateTokenAtoTokenB, uint256 _feePercentage) {
+        require(_tokenA != address(0) && _tokenB != address(0), "Invalid token addresses");
+        require(_rateTokenAtoTokenB > 0, "Rate must be greater than zero");
+        require(_feePercentage <= 10000, "Fee percentage must be between 0 and 100");
+
+        tokenA = IERC20(_tokenA);
+        tokenB = IERC20(_tokenB);
+        rateTokenAtoTokenB = _rateTokenAtoTokenB;
+        feePercentage = _feePercentage;
+    }
+
+    function setRate(uint256 _rate) external onlyOwner {
+        require(_rate > 0, "Rate must be greater than zero");
+        rateTokenAtoTokenB = _rate;
+        emit RateUpdated(_rate);
+    }
+
+    function swapTokenAForTokenB(uint256 _amount) external nonReentrant whenNotPaused {
+        require(_amount > 0, "Amount must be greater than zero");
+
+        uint256 tokenBAmount = (_amount * rateTokenAtoTokenB) / 1e18;
+        uint256 feeAmount = (tokenBAmount * feePercentage) / 10000;
+        uint256 tokenBAmountAfterFee = tokenBAmount - feeAmount;
+
+        tokenA.safeTransferFrom(msg.sender, address(this), _amount);
+        tokenB.safeTransfer(msg.sender, tokenBAmountAfterFee);
+
+        emit TokenSwap(msg.sender, _amount, tokenBAmountAfterFee, true);
+        emit FeeCollected(msg.sender, feeAmount);
+
+        if (feeAmount > 0) {
+            tokenB.safeTransfer(owner(), feeAmount);
+        }
+    }
+
+    function swapTokenBForTokenA(uint256 _amount) external nonReentrant whenNotPaused {
+        require(_amount > 0, "Amount must be greater than zero");
+
+        uint256 tokenAAmount = (_amount * 1e18) / rateTokenAtoTokenB;
+
+        tokenB.safeTransferFrom(msg.sender, address(this), _amount);
+        tokenA.safeTransfer(msg.sender, tokenAAmount);
+
+        emit TokenSwap(msg.sender, _amount, tokenAAmount, false);
+    }
+
+    function setFeePercentage(uint256 _feePercentage) external onlyOwner {
+        require(_feePercentage <= 10000, "Fee percentage must be between 0 and 100");
+        feePercentage = _feePercentage;
+    }
+
+    function pause() external onlyOwner {
+        isPaused = true;
+    }
+
+    function resume() external onlyOwner {
+        isPaused = false;
+    }
+
+    function withdrawTokens(address _token, uint256 _amount) external onlyOwner {
+        require(_amount > 0, "Amount must be greater than zero");
+        IERC20(_token).safeTransfer(owner(), _amount);
+    }
+
+    function withdrawEther(uint256 _amount) external onlyOwner {
+        require(_amount > 0, "Amount must be greater than zero");
+        payable(owner()).transfer(_amount);
+    }
+
+    modifier whenNotPaused() {
+        require(!isPaused, "Contract is paused");
+        _;
+    }
+}

--- a/src/work/SimpleDEXMe2.sol
+++ b/src/work/SimpleDEXMe2.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract SimpleDEX is ReentrancyGuard, Ownable {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable tokenA;
+    IERC20 public immutable tokenB;
+    uint256 public rateTokenAtoTokenB;
+    uint256 public feePercentage;
+    bool public isPaused;
+    bool public emergencyStop;
+    uint256 public slippageTolerance;
+    uint256 public minSwapAmount;
+    uint256 public maxSwapAmount;
+
+    mapping(address => bool) public whitelistedTokens;
+
+    event TokenSwap(address indexed user, uint256 amountA, uint256 amountB, bool fromAToB);
+    event FeeCollected(address indexed user, uint256 amount);
+    event RateUpdated(uint256 newRate);
+    event EmergencyStopActivated();
+    event EmergencyStopDeactivated();
+    event TokenWhitelisted(address indexed token);
+    event TokenRemovedFromWhitelist(address indexed token);
+
+    constructor(address _tokenA, address _tokenB, uint256 _rateTokenAtoTokenB, uint256 _feePercentage) {
+        require(_tokenA != address(0) && _tokenB != address(0), "Invalid token addresses");
+        require(_rateTokenAtoTokenB > 0, "Rate must be greater than zero");
+        require(_feePercentage <= 10000, "Fee percentage must be between 0 and 100");
+
+        tokenA = IERC20(_tokenA);
+        tokenB = IERC20(_tokenB);
+        rateTokenAtoTokenB = _rateTokenAtoTokenB;
+        feePercentage = _feePercentage;
+        slippageTolerance = 50; // 0.5%
+        minSwapAmount = 1e18; // 1 token
+        maxSwapAmount = 1e24; // 1,000,000 tokens
+        whitelistedTokens[_tokenA] = true;
+        whitelistedTokens[_tokenB] = true;
+    }
+
+    function setRate(uint256 _rate) external onlyOwner {
+        require(_rate > 0, "Rate must be greater than zero");
+        rateTokenAtoTokenB = _rate;
+        emit RateUpdated(_rate);
+    }
+
+    function swapTokenAForTokenB(uint256 _amount) external nonReentrant whenNotPaused whenNotEmergencyStopped {
+        require(_amount >= minSwapAmount && _amount <= maxSwapAmount, "Swap amount out of range");
+        require(whitelistedTokens[address(tokenA)] && whitelistedTokens[address(tokenB)], "Tokens are not whitelisted");
+
+        uint256 tokenBAmount = (_amount * rateTokenAtoTokenB) / 1e18;
+        uint256 feeAmount = (tokenBAmount * feePercentage) / 10000;
+        uint256 tokenBAmountAfterFee = tokenBAmount - feeAmount;
+
+        uint256 minTokenBAmount = (tokenBAmountAfterFee * (10000 - slippageTolerance)) / 10000;
+
+        tokenA.safeTransferFrom(msg.sender, address(this), _amount);
+        tokenB.safeTransfer(msg.sender, tokenBAmountAfterFee);
+
+        emit TokenSwap(msg.sender, _amount, tokenBAmountAfterFee, true);
+        emit FeeCollected(msg.sender, feeAmount);
+
+        if (feeAmount > 0) {
+            tokenB.safeTransfer(owner(), feeAmount);
+        }
+
+        require(tokenB.balanceOf(msg.sender) >= minTokenBAmount, "Slippage tolerance exceeded");
+    }
+
+    function swapTokenBForTokenA(uint256 _amount) external nonReentrant whenNotPaused whenNotEmergencyStopped {
+        require(_amount >= minSwapAmount && _amount <= maxSwapAmount, "Swap amount out of range");
+        require(whitelistedTokens[address(tokenA)] && whitelistedTokens[address(tokenB)], "Tokens are not whitelisted");
+
+        uint256 tokenAAmount = (_amount * 1e18) / rateTokenAtoTokenB;
+        uint256 minTokenAAmount = (tokenAAmount * (10000 - slippageTolerance)) / 10000;
+
+        tokenB.safeTransferFrom(msg.sender, address(this), _amount);
+        tokenA.safeTransfer(msg.sender, tokenAAmount);
+
+        emit TokenSwap(msg.sender, _amount, tokenAAmount, false);
+
+        require(tokenA.balanceOf(msg.sender) >= minTokenAAmount, "Slippage tolerance exceeded");
+    }
+
+    function setFeePercentage(uint256 _feePercentage) external onlyOwner {
+        require(_feePercentage <= 10000, "Fee percentage must be between 0 and 100");
+        feePercentage = _feePercentage;
+    }
+
+    function setSlippageTolerance(uint256 _slippageTolerance) external onlyOwner {
+        require(_slippageTolerance <= 10000, "Slippage tolerance must be between 0 and 100");
+        slippageTolerance = _slippageTolerance;
+    }
+
+    function setMinSwapAmount(uint256 _minSwapAmount) external onlyOwner {
+        minSwapAmount = _minSwapAmount;
+    }
+
+    function setMaxSwapAmount(uint256 _maxSwapAmount) external onlyOwner {
+        maxSwapAmount = _maxSwapAmount;
+    }
+
+    function pause() external onlyOwner {
+        isPaused = true;
+    }
+
+    function resume() external onlyOwner {
+        isPaused = false;
+    }
+
+    function toggleEmergencyStop() external onlyOwner {
+        emergencyStop = !emergencyStop;
+        if (emergencyStop) {
+            emit EmergencyStopActivated();
+        } else {
+            emit EmergencyStopDeactivated();
+        }
+    }
+
+    function addWhitelistedToken(address _token) external onlyOwner {
+        require(_token != address(0), "Invalid token address");
+        whitelistedTokens[_token] = true;
+        emit TokenWhitelisted(_token);
+    }
+
+    function removeWhitelistedToken(address _token) external onlyOwner {
+        require(_token != address(0), "Invalid token address");
+        whitelistedTokens[_token] = false;
+        emit TokenRemovedFromWhitelist(_token);
+    }
+
+    function withdrawTokens(address _token, uint256 _amount) external onlyOwner {
+        require(_amount > 0, "Amount must be greater than zero");
+        IERC20(_token).safeTransfer(owner(), _amount);
+    }
+
+    function withdrawEther(uint256 _amount) external onlyOwner {
+        require(_amount > 0, "Amount must be greater than zero");
+        payable(owner()).transfer(_amount);
+    }
+
+    modifier whenNotPaused() {
+        require(!isPaused, "Contract is paused");
+        _;
+    }
+
+    modifier whenNotEmergencyStopped() {
+        require(!emergencyStop, "Emergency stop is activated");
+        _;
+    }
+}


### PR DESCRIPTION
Crowdfunding.sol:
- Renamed `_duration` parameter to `_durationInBlocks` in `createCampaign` for clarity.
- Added whitespace for readability in the refund logic.

LoyaltyPoints.sol:
- Added `Ownable` and `Pausable` from OpenZeppelin.
- Replaced `onlyOwner` modifier with `Ownable`'s implementation.
- Added campaign creator management functions (`addCampaignCreator`, `removeCampaignCreator`) with events.
- Modified `earnPoints` to be callable by both admins and campaign creators.
- Applied `whenNotPaused` modifier to `earnPoints` and `redeemPoints`.
- Updated ether transfer in `redeemPoints` to use `call` instead of `transfer` for gas limit safety.
- Added pause and unpause functions for contract control.